### PR TITLE
MealBook Feature Bug: CheckBox

### DIFF
--- a/js/compliance/complianceService.js
+++ b/js/compliance/complianceService.js
@@ -56,8 +56,12 @@ myApp.factory('Compliance', ["SlotMachine", "IssueCounter", "MealBook", function
         
         //reset all compliance issues
         resetAllComplianceTrackers: function(){
+            //reset the issueCount object to 0;
             IssueCounter.resetCount();
+            
+            //Reset the MealBook tracker to empty and MealBook array found property to false. Therefore reseting checkboxes on the MealBook.html page.
             MealBook.resetMealBookTracker();
+            MealBook.resetMealBookCheckbox();
         }
                 
         

--- a/js/mealBook/mealBookService.js
+++ b/js/mealBook/mealBookService.js
@@ -41,6 +41,13 @@ myApp.factory('MealBook', function () {
         //function to return the list of Mealbook compliance issues.
         getMealBook: function(){
             return mealBook;
+        },
+        
+        //Loop through each element in the mealBook array resetting each element issue's found property to false. This is use when a user save and continue to another slot machine.
+        resetMealBookCheckbox(){                        
+            for(var i=0;i<mealBook.length;i++){
+                mealBook[i].found = false;
+            }
         }
         
     }/*End of main Return*/


### PR DESCRIPTION
Bug: The previous checked checkboxes is not reverting to a pre-unchecked
state when user "Save and Continue" to another slot Machine.

1. Add resetMealBookCheckBox method to the MealBook service. This method
resets each mealBook array's issue found property to false.

2. Add the new method to the Comliance service method
resetAllComplianceTrackers(). The reason is all resets is done in one
place.